### PR TITLE
Add voicetest to Platforms & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ OpenAI Whisper is the most powerful open-source speech recognition model, but do
 | [Vapi](https://vapi.ai/) | Platform for quickly building voice AI agents. Low-code, rich integrations, telephony support. | 低代码快速构建平台 |
 | [Retell AI](https://www.retellai.com/) | Conversational AI platform with enterprise-grade turn-taking management. | 企业级话轮管理 |
 | [Tavus](https://www.tavus.io/) | Real-time conversational video API. Transformer-based turn detection, multimodal video+voice. | 视频+语音多模态 |
+| [voicetest](https://github.com/voicetestdev/voicetest) | Test harness for voice agents. Import from Retell, VAPI, Bland, LiveKit. Run simulations. Evaluate with LLM judges. | 开源测试工具，多平台支持 |
 
 ### Technical Blogs & Documentation | 技术博客与文档
 


### PR DESCRIPTION
Adds [voicetest](https://github.com/voicetestdev/voicetest) — an open-source test harness for voice AI agents supporting Retell, VAPI, Bland, and LiveKit with autonomous simulations and LLM-based evaluation.

Website: https://voicetest.dev