### PR TITLE
Add Unpod.ai to Platforms & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ OpenAI Whisper is the most powerful open-source speech recognition model, but do
 | [Vapi](https://vapi.ai/) | Platform for quickly building voice AI agents. Low-code, rich integrations, telephony support. | 低代码快速构建平台 |
 | [Retell AI](https://www.retellai.com/) | Conversational AI platform with enterprise-grade turn-taking management. | 企业级话轮管理 |
 | [Tavus](https://www.tavus.io/) | Real-time conversational video API. Transformer-based turn detection, multimodal video+voice. | 视频+语音多模态 |
-| [Unpod](https://github.com/parvbhullar/unpod) | Voice infrastructure platform for building AI-native phone and messaging agents. Handles real-time call routing, low-latency speech pipelines, and telephony + SMS automation. | 电话+消息自动化，AI 原生语音基础设施 |
+| [Unpod](https://unpod.ai) | Voice infrastructure platform for building AI-native phone and messaging agents. Handles real-time call routing, low-latency speech pipelines, and telephony + SMS automation. | 电话+消息自动化，AI 原生语音基础设施 \| [GitHub](https://github.com/parvbhullar/unpod) |
 
 ### Technical Blogs & Documentation | 技术博客与文档
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ OpenAI Whisper is the most powerful open-source speech recognition model, but do
 | [Vapi](https://vapi.ai/) | Platform for quickly building voice AI agents. Low-code, rich integrations, telephony support. | 低代码快速构建平台 |
 | [Retell AI](https://www.retellai.com/) | Conversational AI platform with enterprise-grade turn-taking management. | 企业级话轮管理 |
 | [Tavus](https://www.tavus.io/) | Real-time conversational video API. Transformer-based turn detection, multimodal video+voice. | 视频+语音多模态 |
-| [Unpod.ai](https://unpod.ai) | Voice infrastructure platform for building AI-native phone and messaging agents. Handles real-time call routing, low-latency speech pipelines, and telephony + SMS automation. | 电话+消息自动化，AI 原生语音基础设施 |
+| [Unpod](https://github.com/parvbhullar/unpod) | Voice infrastructure platform for building AI-native phone and messaging agents. Handles real-time call routing, low-latency speech pipelines, and telephony + SMS automation. | 电话+消息自动化，AI 原生语音基础设施 |
 
 ### Technical Blogs & Documentation | 技术博客与文档
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ OpenAI Whisper is the most powerful open-source speech recognition model, but do
 | [Vapi](https://vapi.ai/) | Platform for quickly building voice AI agents. Low-code, rich integrations, telephony support. | 低代码快速构建平台 |
 | [Retell AI](https://www.retellai.com/) | Conversational AI platform with enterprise-grade turn-taking management. | 企业级话轮管理 |
 | [Tavus](https://www.tavus.io/) | Real-time conversational video API. Transformer-based turn detection, multimodal video+voice. | 视频+语音多模态 |
+| [Unpod.ai](https://unpod.ai) | Voice infrastructure platform for building AI-native phone and messaging agents. Handles real-time call routing, low-latency speech pipelines, and telephony + SMS automation. | 电话+消息自动化，AI 原生语音基础设施 |
 
 ### Technical Blogs & Documentation | 技术博客与文档
 


### PR DESCRIPTION
Added [Unpod.ai](https://unpod.ai) to the Platforms & Tools section.

Unpod.ai is a voice infrastructure platform that lets you build AI-native phone and messaging agents. It handles real-time call routing, low-latency speech pipelines, and telephony + SMS automation — the kind of infrastructure layer that sits between raw SIP/RTP and the LLM, so developers don't have to wire it themselves.

Fits alongside Vapi and Retell AI in the commercial platforms section.