### PR TITLE
feat: add clawcall — Twilio↔OpenClaw voice bridge with full agent tool access

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Add WeChat | 添加微信: **1796060717**
 | Name | Stars | Description | Notes |
 |------|-------|-------------|-------|
 | [BentoVoiceAgent](https://github.com/bentoml/BentoVoiceAgent) | ![GitHub Repo stars](https://badgen.net/github/stars/bentoml/BentoVoiceAgent) | Build phone calling voice agents fully powered by open source models. Uses BentoML for deployment. | 完全基于开源模型 |
+| [clawcall](https://github.com/CODEANDTRUST/clawcall) | ![GitHub Repo stars](https://badgen.net/github/stars/CODEANDTRUST/clawcall) | Self-hostable Twilio↔OpenClaw gateway bridge: routes every inbound caller utterance through a full agent turn (STT→chat.send→TTS) with native tool access mid-call. MIT, TypeScript. | Twilio 入站电话→ OpenClaw 网关，工具调用全程可用 |
 | [LangGraph Voice Agent](https://github.com/Rajathbharadwaj/voice-agent) | ![GitHub Repo stars](https://badgen.net/github/stars/Rajathbharadwaj/voice-agent) | Voice AI SDR Agent for automated sales calls. Built with LangGraph, Twilio, and OpenAI. Production-ready with call routing, objection handling, and appointment scheduling. | LangGraph 架构，销售自动化 |
 | [RealtimeVoiceChat](https://github.com/KoljaB/RealtimeVoiceChat) | ![GitHub Repo stars](https://badgen.net/github/stars/KoljaB/RealtimeVoiceChat) | Browser-to-Python stack for ~500ms natural spoken conversation with local LLMs (Ollama). Built on RealtimeSTT + RealtimeTTS. | 本地语音对话栈，约 500ms 延迟 |
 


### PR DESCRIPTION
## What this adds

[**CODEANDTRUST/clawcall**](https://github.com/CODEANDTRUST/clawcall) — a self-hostable TypeScript service that bridges Twilio inbound phone calls to an [OpenClaw](https://github.com/openclaw/openclaw) gateway, running a **full agent turn** (Deepgram STT → `chat.send` → ElevenLabs TTS) on every utterance with native tool access mid-call. MIT license.

## Why it fits this list

- Fits the **Specialized Solutions** table: it's a concrete, production-usable telephony voice-agent implementation alongside existing Twilio-based entries
- Uses Deepgram (STT) + ElevenLabs (TTS) — two providers already referenced in this list
- Self-hostable, open-source (MIT), TypeScript
- Companion guide: https://www.codeandtrust.com/blog/openclaw-phone-calls

## Checklist

- [x] One entry added, existing entries untouched
- [x] Matches table format (Name | Stars badge | Description | Notes)
- [x] MIT license, actively maintained, English