### PR TITLE
Add PhoneMic to CLI & Local Dictation Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Turn Detection/Endpointing determines when a user has finished speaking - a core
 OpenAI Whisper is the most powerful open-source speech recognition model, but doesn't natively support real-time streaming. The following projects implement streaming transcription:
 
 | Name | Stars | Description | Notes |
-|------|-------|-------------|-------|
+|------|-------|----------|
 | [WhisperLiveKit](https://github.com/QuentinFuxa/WhisperLiveKit) | ![GitHub Repo stars](https://badgen.net/github/stars/QuentinFuxa/WhisperLiveKit) | Real-time, fully local speech-to-text with speaker diarization; web UI plus FastAPI server, built on SimulStreaming/WhisperStreaming. | 同步实时语音转文字，含说话人分离，全本地可部署 |
 | [Whisper Streaming (UFAL)](https://github.com/ufal/whisper_streaming) | ![GitHub Repo stars](https://badgen.net/github/stars/ufal/whisper_streaming) | Whisper realtime streaming for long speech-to-text. Local agreement policy with self-adaptive latency. 3.3s latency. | 使用局部一致性策略，自适应延迟 |
 | [WhisperLive](https://github.com/collabora/WhisperLive) | ![GitHub Repo stars](https://badgen.net/github/stars/collabora/WhisperLive) | Nearly-live implementation of OpenAI's Whisper. TensorRT acceleration support. Browser extensions and iOS client. | 支持 TensorRT 加速和多平台 |
@@ -378,6 +378,7 @@ High-star, general-purpose voice/speech projects: end-to-end toolkits, wake-word
 | [vibe](https://github.com/thewh1teagle/vibe) | ![GitHub Repo stars](https://badgen.net/github/stars/thewh1teagle/vibe) | Cross-platform offline audio/video transcription (90+ languages, diarization) with CLI and HTTP API. | 跨平台离线音视频转录，含 CLI 与 HTTP API |
 | [WhisperWriter](https://github.com/savbell/whisper-writer) | ![GitHub Repo stars](https://badgen.net/github/stars/savbell/whisper-writer) | Small Python dictation app: hotkey listens, then auto-types Whisper transcription into the active window. | 轻量 Python 听写，热键触发自动输入 |
 | [nerd-dictation](https://github.com/ideasman42/nerd-dictation) | ![GitHub Repo stars](https://badgen.net/github/stars/ideasman42/nerd-dictation) | Single-file, hackable offline speech-to-text for Linux using VOSK, with Python-based text post-processing. | 单文件可魔改的 Linux 离线听写 |
+| [PhoneMic](https://github.com/DJKING792/PhoneMic) | ![GitHub Repo stars](https://badgen.net/github/stars/DJKING792/PhoneMic) | Turn your phone into a wireless microphone — record in the phone browser over LAN HTTPS, transcribed by Xiaomi MiMo ASR and auto-pasted into the PC cursor. No app, no cable; Win/Mac/Linux. | 把手机变成电脑的无线麦克风：手机浏览器录音经局域网上传，小米 MiMo 识别后自动粘贴到光标，无需 App 与数据线，跨平台。 |
 | [wyoming-satellite](https://github.com/rhasspy/wyoming-satellite) | ![GitHub Repo stars](https://badgen.net/github/stars/rhasspy/wyoming-satellite) | Remote voice satellite (Wyoming protocol) for Home Assistant on Raspberry Pi with local wake-word detection. | Home Assistant 远程语音卫星，树莓派+本地唤醒词 |
 
 ---

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Turn Detection/Endpointing determines when a user has finished speaking - a core
 OpenAI Whisper is the most powerful open-source speech recognition model, but doesn't natively support real-time streaming. The following projects implement streaming transcription:
 
 | Name | Stars | Description | Notes |
-|------|-------|----------|
+|------|-------|-------------|-------|
 | [WhisperLiveKit](https://github.com/QuentinFuxa/WhisperLiveKit) | ![GitHub Repo stars](https://badgen.net/github/stars/QuentinFuxa/WhisperLiveKit) | Real-time, fully local speech-to-text with speaker diarization; web UI plus FastAPI server, built on SimulStreaming/WhisperStreaming. | 同步实时语音转文字，含说话人分离，全本地可部署 |
 | [Whisper Streaming (UFAL)](https://github.com/ufal/whisper_streaming) | ![GitHub Repo stars](https://badgen.net/github/stars/ufal/whisper_streaming) | Whisper realtime streaming for long speech-to-text. Local agreement policy with self-adaptive latency. 3.3s latency. | 使用局部一致性策略，自适应延迟 |
 | [WhisperLive](https://github.com/collabora/WhisperLive) | ![GitHub Repo stars](https://badgen.net/github/stars/collabora/WhisperLive) | Nearly-live implementation of OpenAI's Whisper. TensorRT acceleration support. Browser extensions and iOS client. | 支持 TensorRT 加速和多平台 |


### PR DESCRIPTION
## Add PhoneMic — turn your phone into a wireless microphone for your PC

PhoneMic lets you use your phone as a wireless microphone for your computer. It records audio in the phone's browser over a local LAN HTTPS connection, transcribes it with Xiaomi's MiMo ASR, and auto-pastes the text directly at your PC cursor — no app install, no cable, works on Win/Mac/Linux.

**Why this belongs in _CLI & Local Dictation Tools_:**
- 100% local / privacy-first dictation workflow — audio stays on your LAN and is transcribed locally, never sent to a public cloud.
- Output is delivered straight to the active text cursor, exactly like a CLI / local dictation tool.
- No cloud account or SaaS dependency — fits the self-hosted / local-first spirit of this list.

Repo: https://github.com/DJKING792/PhoneMic

---

## 添加 PhoneMic —— 把手机变成电脑的无线麦克风

PhoneMic 可将手机作为电脑的无线麦克风：手机浏览器通过局域网 HTTPS 录音，经小米 MiMo 语音识别后在 PC 光标处自动粘贴文字，无需安装 App、无需数据线，支持 Win/Mac/Linux。

**归入 CLI & Local Dictation Tools 的理由：**
- 完全的本地 / 隐私优先听写流程（音频全程留在局域网，本地转录，不经过公网）。
- 识别结果直接送到当前光标处，与本地听写工具的使用方式一致。
- 不依赖任何云服务账号或 SaaS，契合本清单自托管 / 本地优先的理念。

如需调整措辞、分类位置或格式以符合清单规范，请随时告知。感谢维护这份优秀的清单！