### PR TITLE
Add hotato (voice-agent regression testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ High-star, general-purpose voice/speech projects: end-to-end toolkits, wake-word
 | [Tavus](https://www.tavus.io/) | Real-time conversational video API. Transformer-based turn detection, multimodal video+voice. | 视频+语音多模态 |
 | [Unpod](https://unpod.ai) | Voice infrastructure platform for building AI-native phone and messaging agents. Handles real-time call routing, low-latency speech pipelines, and telephony + SMS automation. | 电话+消息自动化，AI 原生语音基础设施 \| [GitHub](https://github.com/geneffic/unpod) |
 | [voicetest](https://github.com/voicetestdev/voicetest) | Test harness for voice agents. Import from Retell, VAPI, Bland, LiveKit. Run simulations. Evaluate with LLM judges. | 开源测试工具，多平台支持 |
+| [hotato](https://github.com/attenlabs/hotato) | Regression testing for voice agents. Scores turn timing from two-channel recordings, verifies say-do against traces, gates CI. | 开源回归测试，CI 门禁 |
 
 ### Technical Blogs & Documentation | 技术博客与文档
 


### PR DESCRIPTION
hotato scores turn timing from two-channel call recordings, verifies what the agent said against backend traces, and gates CI on the exit code. MIT, on PyPI.

Disclosure: maker submission.