### PR TITLE
Add AI Dictation to local dictation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ High-star, general-purpose voice/speech projects: end-to-end toolkits, wake-word
 
 | Name | Stars | Description | Notes |
 |------|-------|-------------|-------|
+| [AI Dictation](https://github.com/writingmate/aidictation) | ![GitHub Repo stars](https://badgen.net/github/stars/writingmate/aidictation) | MIT-licensed voice-to-text app for macOS, Windows, iOS and Android, with offline recognition on supported devices and optional cloud transcription and cleanup. | MIT 开源跨平台语音输入；支持设备可用离线识别，也可选云端转写和润色。 |
 | [Handy](https://github.com/cjpais/Handy) | ![GitHub Repo stars](https://badgen.net/github/stars/cjpais/Handy) | Free, fully-offline push-to-talk dictation app (Tauri/Rust) for Win/Mac/Linux using Whisper + Parakeet, auto-pasting into any field. | 全离线按键说话听写，跨平台，自动粘贴 |
 | [vibe](https://github.com/thewh1teagle/vibe) | ![GitHub Repo stars](https://badgen.net/github/stars/thewh1teagle/vibe) | Cross-platform offline audio/video transcription (90+ languages, diarization) with CLI and HTTP API. | 跨平台离线音视频转录，含 CLI 与 HTTP API |
 | [WhisperWriter](https://github.com/savbell/whisper-writer) | ![GitHub Repo stars](https://badgen.net/github/stars/savbell/whisper-writer) | Small Python dictation app: hotkey listens, then auto-types Whisper transcription into the active window. | 轻量 Python 听写，热键触发自动输入 |


### PR DESCRIPTION
## Summary | 摘要

Adds AI Dictation to **CLI & Local Dictation Tools** as an MIT-licensed cross-platform voice-to-text app. The wording distinguishes offline recognition on supported devices from optional cloud transcription and cleanup.

将 AI Dictation 添加到 **CLI & Local Dictation Tools**。条目明确区分“支持设备上的离线识别”和“可选的云端转写/润色”，不声称所有平台或所有功能都完全离线。

## Verification | 核验

- Source and MIT license | 源码与 MIT 许可证: https://github.com/writingmate/aidictation
- Product site | 官网: https://aidictation.com
- Current repository documentation covers macOS, Windows, iOS, and Android, and current releases show active maintenance.

## Disclosure | 披露

I am affiliated with AI Dictation and am submitting it openly rather than presenting this as an independent recommendation. The entry and PR text were prepared with AI assistance and checked against the current repository and this list's contribution instructions.

我与 AI Dictation 项目有关联，并公开说明这是项目方提交，而非独立推荐。本条目及 PR 文本使用了 AI 辅助，并已对照当前仓库和贡献说明进行核验。