### PR TITLE
Add DialogBrain to Commercial Speech-to-Speech Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Add WeChat | 添加江树微信: **1796060717**
 | [Amazon Nova Sonic](https://aws.amazon.com/ai/generative-ai/nova/) | AWS Bedrock speech-to-speech foundation model with polyglot voices, async tool calling, large context, LiveKit/Pipecat integrations. | AWS 语音到语音大模型，多语种同声、异步工具调用 |
 | [Speechmatics Flow](https://www.speechmatics.com/flow) | Conversational voice-agent API built on high-accuracy multilingual ASR with sentiment/tone awareness. | 基于高精度多语种 ASR 的对话语音 Agent API |
 | [Agora Conversational AI Engine](https://www.agora.io/en/products/conversational-ai-engine/) | Real-time RTC platform orchestrating ASR + any LLM + TTS for global low-latency voice agents. | 全球实时通信厂商的语音 Agent 引擎，低延迟 |
+| [DialogBrain](https://dialogbrain.com/voice/api) | Multi-channel voice agent platform: agents make and take calls on Telegram, WhatsApp, Google Meet and web widgets, with real-time multi-language call translation, lipsync avatars and an MCP API (244+ tools). | 多渠道语音 Agent 平台，支持 Telegram/WhatsApp/Meet 通话、实时多语同传与 MCP API |
 ---
 
 ## VAD (Voice Activity Detection) | 语音活动检测


### PR DESCRIPTION
Adds [DialogBrain](https://dialogbrain.com/voice/api) — a commercial multi-channel voice agent platform: agents make and take real calls on Telegram, WhatsApp, Google Meet, and embeddable web widgets, with real-time multi-language call translation, lipsync avatars, and a hosted MCP API (244+ tools, listed on the official MCP Registry and Smithery). Docs: https://docs.dialogbrain.com/

Disclosure: I'm the founder. Happy to adjust wording or placement.